### PR TITLE
Fix Windows not snapping on taskbars...

### DIFF
--- a/hooks.c
+++ b/hooks.c
@@ -230,8 +230,11 @@ BOOL CALLBACK EnumMonitorsProc(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMon
     monitors_alloc++;
     monitors = realloc(monitors, monitors_alloc*sizeof(RECT));
   }
-  // Add monitor
-  monitors[nummonitors++] = *lprcMonitor;
+  // Add monitor using the rcWork rect
+  // that takes taskbars into account unlike the lprcMonitor...
+  MONITORINFO mi = { sizeof(MONITORINFO) };
+  GetMonitorInfo(hMonitor, &mi);
+  monitors[nummonitors++] =  mi.rcWork;
   return TRUE;
 }
 
@@ -357,12 +360,6 @@ void Enum() {
   // Enumerate monitors
   EnumDisplayMonitors(NULL, NULL, EnumMonitorsProc, 0);
 
-  // Enumerate windows
-  HWND taskbar = FindWindow(L"Shell_TrayWnd", NULL);
-  RECT wnd;
-  if (taskbar != NULL && GetWindowRect(taskbar,&wnd) != 0) {
-    wnds[numwnds++] = wnd;
-  }
   if (sharedstate.snap >= 2) {
     EnumWindows(EnumWindowsProc, 0);
   }


### PR DESCRIPTION
..in secondary monitors

The rcWork field of the monitor is used instead of the lprcMonitor parameter in the EnumMonitorsProc function.
This also removes the need to specifically search for the Taskbar window. in the Enum() function

Fixes: https://github.com/stefansundin/altdrag/issues/108