### PR TITLE
Improve cursorwnd

### DIFF
--- a/altdrag.c
+++ b/altdrag.c
@@ -172,8 +172,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInstance, char *szCmdLine, in
   // Create window
   WNDCLASSEX wnd = { sizeof(WNDCLASSEX), 0, WindowProc, 0, 0, hInst, NULL, NULL, (HBRUSH)(COLOR_WINDOW+1), NULL, APP_NAME, NULL };
   RegisterClassEx(&wnd);
-  g_hwnd = CreateWindowEx(WS_EX_TOOLWINDOW|WS_EX_TOPMOST|WS_EX_LAYERED, wnd.lpszClassName, NULL, WS_POPUP, 0, 0, 0, 0, NULL, NULL, hInst, NULL);
-  SetLayeredWindowAttributes(g_hwnd, 0, 1, LWA_ALPHA); // Almost transparent
+  g_hwnd = CreateWindowEx(WS_EX_TOOLWINDOW|WS_EX_TOPMOST|WS_EX_TRANSPARENT, wnd.lpszClassName, NULL, WS_POPUP, 0, 0, 0, 0, NULL, NULL, hInst, NULL);
 
   // Tray icon
   InitTray();
@@ -447,6 +446,9 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
   else if (msg == WM_LBUTTONDOWN || msg == WM_MBUTTONDOWN || msg == WM_RBUTTONDOWN) {
     // Hide cursorwnd if clicked on, this might happen if it wasn't hidden by hooks.c for some reason
     ShowWindow(hwnd, SW_HIDE);
+  }
+  else if (wParam && (msg == WM_PAINT || msg == WM_ERASEBKGND)){
+      return 0; // Do nothing when asked to paint!
   }
   return DefWindowProc(hwnd, msg, wParam, lParam);
 }

--- a/hooks.c
+++ b/hooks.c
@@ -1120,7 +1120,7 @@ __declspec(dllexport) LRESULT CALLBACK LowLevelMouseProc(int nCode, WPARAM wPara
         state.updaterate = (state.updaterate+1)%(sharedstate.action==ACTION_MOVE?sharedsettings.Performance.MoveRate:sharedsettings.Performance.ResizeRate);
         if (state.updaterate == 0) {
           if (sharedsettings.Performance.Cursor) {
-            MoveWindow(cursorwnd, pt.x-20, pt.y-20, 41, 41, TRUE);
+            MoveWindow(cursorwnd, pt.x-128, pt.y-128, 256, 256, FALSE);
             //MoveWindow(cursorwnd,(prevpt.x<pt.x?prevpt.x:pt.x)-3,(prevpt.y<pt.y?prevpt.y:pt.y)-3,(pt.x>prevpt.x?pt.x-prevpt.x:prevpt.x-pt.x)+7,(pt.y>prevpt.y?pt.y-prevpt.y:prevpt.y-pt.y)+7,FALSE);
           }
           MouseMove();


### PR DESCRIPTION
Use the `WS_EX_TRANSPARENT` attribute instead of WS_EX_LAYERED for the g_hwnd/cursorwnd
It is much more fast when you have no desktop composition.
There are no longer any performances hit!
The size of the cursor window was also increased to avoid the pointer from blinking between different cursors when moving or resizing fast.

